### PR TITLE
Update copyright to be based on the primary MIT-style LICENSE file

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Body.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Body.h
@@ -3,7 +3,8 @@
 //  RCTAppleHealthKit
 //
 //  Created by Greg Wilson on 2016-06-26.
-//  Copyright © 2016 Greg Wilson. All rights reserved.
+//  This source code is licensed under the MIT-style license found in the
+//  LICENSE file in the root directory of this source tree.
 //
 
 #import "RCTAppleHealthKit.h"

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Body.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Body.m
@@ -3,7 +3,8 @@
 //  RCTAppleHealthKit
 //
 //  Created by Greg Wilson on 2016-06-26.
-//  Copyright © 2016 Greg Wilson. All rights reserved.
+//  This source code is licensed under the MIT-style license found in the
+//  LICENSE file in the root directory of this source tree.
 //
 
 #import "RCTAppleHealthKit+Methods_Body.h"

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Characteristic.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Characteristic.h
@@ -3,7 +3,8 @@
 //  RCTAppleHealthKit
 //
 //  Created by Greg Wilson on 2016-06-29.
-//  Copyright © 2016 Greg Wilson. All rights reserved.
+//  This source code is licensed under the MIT-style license found in the
+//  LICENSE file in the root directory of this source tree.
 //
 
 #import "RCTAppleHealthKit.h"

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Characteristic.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Characteristic.m
@@ -3,7 +3,8 @@
 //  RCTAppleHealthKit
 //
 //  Created by Greg Wilson on 2016-06-29.
-//  Copyright © 2016 Greg Wilson. All rights reserved.
+//  This source code is licensed under the MIT-style license found in the
+//  LICENSE file in the root directory of this source tree.
 //
 
 #import "RCTAppleHealthKit+Methods_Characteristic.h"

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.h
@@ -3,7 +3,8 @@
 //  RCTAppleHealthKit
 //
 //  Created by Greg Wilson on 2016-06-26.
-//  Copyright © 2016 Greg Wilson. All rights reserved.
+//  This source code is licensed under the MIT-style license found in the
+//  LICENSE file in the root directory of this source tree.
 //
 
 #import "RCTAppleHealthKit.h"

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
@@ -3,7 +3,8 @@
 //  RCTAppleHealthKit
 //
 //  Created by Greg Wilson on 2016-06-26.
-//  Copyright © 2016 Greg Wilson. All rights reserved.
+//  This source code is licensed under the MIT-style license found in the
+//  LICENSE file in the root directory of this source tree.
 //
 
 #import "RCTAppleHealthKit+Methods_Fitness.h"

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Sleep.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Sleep.h
@@ -3,7 +3,8 @@
 //  RCTAppleHealthKit
 //
 //  Created by Greg Wilson on 2016-11-06.
-//  Copyright © 2016 Greg Wilson. All rights reserved.
+//  This source code is licensed under the MIT-style license found in the
+//  LICENSE file in the root directory of this source tree.
 //
 
 #import "RCTAppleHealthKit.h"

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Sleep.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Sleep.m
@@ -3,7 +3,8 @@
 //  RCTAppleHealthKit
 //
 //  Created by Greg Wilson on 2016-11-06.
-//  Copyright © 2016 Greg Wilson. All rights reserved.
+//  This source code is licensed under the MIT-style license found in the
+//  LICENSE file in the root directory of this source tree.
 //
 
 

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Queries.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Queries.h
@@ -3,7 +3,8 @@
 //  RCTAppleHealthKit
 //
 //  Created by Greg Wilson on 2016-06-26.
-//  Copyright © 2016 Greg Wilson. All rights reserved.
+//  This source code is licensed under the MIT-style license found in the
+//  LICENSE file in the root directory of this source tree.
 //
 
 #import "RCTAppleHealthKit.h"

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
@@ -3,7 +3,8 @@
 //  RCTAppleHealthKit
 //
 //  Created by Greg Wilson on 2016-06-26.
-//  Copyright © 2016 Greg Wilson. All rights reserved.
+//  This source code is licensed under the MIT-style license found in the
+//  LICENSE file in the root directory of this source tree.
 //
 
 #import "RCTAppleHealthKit+Queries.h"

--- a/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.h
@@ -3,7 +3,8 @@
 //  RCTAppleHealthKit
 //
 //  Created by Greg Wilson on 2016-06-26.
-//  Copyright © 2016 Greg Wilson. All rights reserved.
+//  This source code is licensed under the MIT-style license found in the
+//  LICENSE file in the root directory of this source tree.
 //
 
 #import "RCTAppleHealthKit.h"

--- a/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
@@ -3,7 +3,8 @@
 //  RCTAppleHealthKit
 //
 //  Created by Greg Wilson on 2016-06-26.
-//  Copyright © 2016 Greg Wilson. All rights reserved.
+//  This source code is licensed under the MIT-style license found in the
+//  LICENSE file in the root directory of this source tree.
 //
 
 #import "RCTAppleHealthKit+TypesAndPermissions.h"

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Utils.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Utils.h
@@ -3,7 +3,8 @@
 //  RCTAppleHealthKit
 //
 //  Created by Greg Wilson on 2016-06-26.
-//  Copyright © 2016 Greg Wilson. All rights reserved.
+//  This source code is licensed under the MIT-style license found in the
+//  LICENSE file in the root directory of this source tree.
 //
 
 #import "RCTAppleHealthKit.h"

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Utils.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Utils.m
@@ -3,7 +3,8 @@
 //  RCTAppleHealthKit
 //
 //  Created by Greg Wilson on 2016-06-26.
-//  Copyright © 2016 Greg Wilson. All rights reserved.
+//  This source code is licensed under the MIT-style license found in the
+//  LICENSE file in the root directory of this source tree.
 //
 
 #import "RCTAppleHealthKit+Utils.h"

--- a/RCTAppleHealthKit/RCTAppleHealthKit.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.h
@@ -3,7 +3,8 @@
 //  RCTAppleHealthKit
 //
 //  Created by Greg Wilson on 2016-06-26.
-//  Copyright © 2016 Greg Wilson. All rights reserved.
+//  This source code is licensed under the MIT-style license found in the
+//  LICENSE file in the root directory of this source tree.
 //
 
 #import <Foundation/Foundation.h>

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -3,7 +3,8 @@
 //  RCTAppleHealthKit
 //
 //  Created by Greg Wilson on 2016-06-26.
-//  Copyright © 2016 Greg Wilson. All rights reserved.
+//  This source code is licensed under the MIT-style license found in the
+//  LICENSE file in the root directory of this source tree.
 //
 
 #import "RCTAppleHealthKit.h"


### PR DESCRIPTION
Update copyright in some files to be based on the primary MIT-style LICENSE in the root directory, rather than all rights reserved.

For legal reasons in some production software, having 'all rights reserved' means that this package cannot be used.