### PR TITLE
Support React Native 0.56

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,31 @@ Install the [rn-apple-healthkit] package from npm:
 - Run `npm install rn-apple-healthkit --save`
 - Run `react-native link rn-apple-healthkit`
 
-Update `info.plist` in your React Native project
-```
+Update `Info.plist` in your React Native project
+
+```xml
 <key>NSHealthShareUsageDescription</key>
 <string>Read and understand health data.</string>
 <key>NSHealthUpdateUsageDescription</key>
 <string>Share workout data with other apps.</string>
 ```
+
+### With `react-native@0.56`
+
+From version 0.56, React Native uses [Babel 7 beta](https://babeljs.io/docs/en/next/index.html), there're some extra configurations needed to integrate this module to your iOS project successfully, as below:
+
+- Install `@babel/plugin-transform-runtime` and `@babel/runtime` as [instructed here](https://babeljs.io/docs/en/next/babel-plugin-transform-runtime#installation)
+- Add `@babel/plugin-transform-runtime` to `plugins` section in `babel.config.js` file (from version 7, Babel uses [`babel.config.js` file](https://babeljs.io/docs/en/next/babelconfigjs) in root folder instead of `.babelrc`):
+
+```git
+module.exports = {
++  plugins: [
++    '@babel/plugin-transform-runtime',
++  ],
+  presets: ['react-native'],
+};
+```
+- Then normally run `react-native link rn-apple-healthkit` as mentioned above.
 
 ## Manual Installation
 

--- a/index.js
+++ b/index.js
@@ -1,16 +1,16 @@
-'use strict'
+"use strict";
 
-let { AppleHealthKit } = require('react-native').NativeModules;
+let { AppleHealthKit } = require("react-native").NativeModules;
 
-import { Permissions } from './Constants/Permissions'
-import { Units } from './Constants/Units'
+import { Permissions } from "./Constants/Permissions";
+import { Units } from "./Constants/Units";
 
-let HealthKit = Object.assign({}, AppleHealthKit, {
-	Constants: {
-		Permissions: Permissions,
-		Units: Units,
-	}
-});
+let HealthKit = AppleHealthKit;
 
-export default HealthKit
+HealthKit.Constants = {
+  Permissions,
+  Units,
+};
+
+export default HealthKit;
 module.exports = HealthKit;


### PR DESCRIPTION
# 1. Babel 7

After upgrading to React Native 0.56, which uses Babel 7 beta, developers may face the error while linking the library

```shell
rnpm-install ERR! Something went wrong while linking. Error: regeneratorRuntime is not defined
Please file an issue here: https://github.com/facebook/react-native/issues

regeneratorRuntime is not defined
```

This could be resolved by installing [Babel's `transform-runtime` plugin](https://babeljs.io/docs/en/next/babel-plugin-transform-runtime#installation).

# 2. `Object.assign`

After successfully linked & run, the application could face another error: `$export is not a function`

![rn-apple-healthkit-babel-7](https://user-images.githubusercontent.com/1215541/43592907-c36d9658-96a0-11e8-9720-0b91118a8730.png)

which invoked from `core-js/library/modules/es6.object.define-property.js`:

```javascript
var $export = require('./_export');
// 19.1.2.4 / 15.2.3.6 Object.defineProperty(O, P, Attributes)
$export($export.S + $export.F * !require('./_descriptors'), 'Object', { defineProperty: require('./_object-dp').f });
```

After inspecting, I found that it has errors because the usage of `Object.assign` in `index.js`:

```javascript
let HealthKit = Object.assign({}, AppleHealthKit, {
	Constants: {
		Permissions: Permissions,
		Units: Units,
	}
});
```

If changing this into:

```javascript
let HealthKit = AppleHealthKit;

HealthKit.Constants = {
  Permissions,
  Units,
};
```

the project works fine.

This PR includes:

  - Fixes in `index.js` to avoid `Object.assign()` usage
  - Added section **With react-native@0.56** to `README.md`