### PR TITLE
[FEAT]Add daily Vo2Max samples support

### DIFF
--- a/Constants/Permissions.js
+++ b/Constants/Permissions.js
@@ -66,5 +66,6 @@ export const Permissions = {
   SleepAnalysis: "SleepAnalysis",
   StepCount: "StepCount",
   Steps: "Steps",
-  Weight: "Weight"
+  Weight: "Weight",
+  Vo2Max: "Vo2Max"
 }

--- a/Constants/Units.js
+++ b/Constants/Units.js
@@ -23,5 +23,6 @@ export const Units = {
   mmolPerL: "mmolPerL",
   percent: "percent",
   pound: "pound",
-  second: "second"
+  second: "second",
+  mlPerKgMin: "mlPerKgMin"
 }

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Vitals.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Vitals.h
@@ -6,5 +6,6 @@
 - (void)vitals_getBodyTemperatureSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)vitals_getBloodPressureSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)vitals_getRespiratoryRateSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)vitals_getVo2MaxSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 
 @end

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Vitals.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Vitals.m
@@ -163,4 +163,37 @@
     }];
 }
 
+- (void)vitals_getVo2MaxSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback {
+  HKQuantityType *vo2MaxType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierVO2Max];
+
+  HKUnit *ml = [HKUnit literUnitWithMetricPrefix:HKMetricPrefixMilli];
+  HKUnit *kg = [HKUnit gramUnitWithMetricPrefix:HKMetricPrefixKilo];
+  HKUnit *min = [HKUnit minuteUnit];
+  HKUnit *u = [ml unitDividedByUnit:[kg unitMultipliedByUnit:min]]; // ml/(kg*min)
+
+  HKUnit *unit = [RCTAppleHealthKit hkUnitFromOptions:input key:@"unit" withDefault:u];
+  NSUInteger limit = [RCTAppleHealthKit uintFromOptions:input key:@"limit" withDefault:HKObjectQueryNoLimit];
+  BOOL ascending = [RCTAppleHealthKit boolFromOptions:input key:@"ascending" withDefault:false];
+  NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:nil];
+  NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:[NSDate date]];
+
+  NSPredicate * predicate = [RCTAppleHealthKit predicateForSamplesBetweenDates:startDate endDate:endDate];
+  [self fetchQuantitySamplesOfType:vo2MaxType
+                              unit:unit
+                         predicate:predicate
+                         ascending:ascending
+                             limit:limit
+                        completion:^(NSArray *results, NSError *error) {
+                          if(results){
+                            callback(@[[NSNull null], results]);
+                            return;
+                          } else {
+                            NSString *errStr = [NSString stringWithFormat:@"error getting Vo2Max samples: %@", error];
+                            NSLog(errStr);
+                            callback(@[RCTMakeError(errStr, nil, nil)]);
+                            return;
+                          }
+                        }];
+}
+
 @end

--- a/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
@@ -14,7 +14,7 @@
 #pragma mark - HealthKit Permissions
 
 - (NSDictionary *)readPermsDict {
-    NSDictionary *readPerms = @{
+    NSMutableDictionary *readPerms = [@{
         // Characteristic Identifiers
         @"DateOfBirth" : [HKObjectType characteristicTypeForIdentifier:HKCharacteristicTypeIdentifierDateOfBirth],
         @"BiologicalSex" : [HKObjectType characteristicTypeForIdentifier:HKCharacteristicTypeIdentifierBiologicalSex],
@@ -49,7 +49,10 @@
         @"SleepAnalysis" : [HKObjectType categoryTypeForIdentifier:HKCategoryTypeIdentifierSleepAnalysis],
         // Mindfulness
         @"MindfulSession" : [HKObjectType categoryTypeForIdentifier:HKCategoryTypeIdentifierMindfulSession],
-    };
+    } mutableCopy];
+    if (@available(iOS 11.0, *)) {
+      readPerms[@"Vo2Max"] = [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierVO2Max];
+    }
     return readPerms;
 }
 

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Utils.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Utils.m
@@ -244,6 +244,13 @@
     if([unitString isEqualToString:@"mgPerdL"]){
         theUnit = [HKUnit unitFromString:@"mg/dL"];
     }
+    if([unitString isEqualToString:@"mlPerKgMin"]) {
+      // ml / (kg * min)
+      HKUnit *ml = [HKUnit literUnitWithMetricPrefix:HKMetricPrefixMilli];
+      HKUnit *kg = [HKUnit gramUnitWithMetricPrefix:HKMetricPrefixKilo];
+      HKUnit *min = [HKUnit minuteUnit];
+      theUnit = [ml unitDividedByUnit:[kg unitMultipliedByUnit:min]];
+    }
 
     if(theUnit == nil){
         theUnit = defaultValue;

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -187,6 +187,11 @@ RCT_EXPORT_METHOD(getRespiratoryRateSamples:(NSDictionary *)input callback:(RCTR
     [self vitals_getRespiratoryRateSamples:input callback:callback];
 }
 
+RCT_EXPORT_METHOD(getVo2MaxSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+  [self vitals_getVo2MaxSamples:input callback:callback];
+}
+
 RCT_EXPORT_METHOD(getBloodGlucoseSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
 {
     [self results_getBloodGlucoseSamples:input callback:callback];

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ AppleHealthKit.initHealthKit(options: Object, (err: string, results: Object) => 
       * [getLatestLeanBodyMass](/docs/getlatestleanbodymass().md)
       * [getLatestWeight](/docs/getlatestweight().md)
       * [getRespiratoryRateSamples](/docs/getrespiratoryratesamples().md)
+      * [getVo2MaxSamples](/docs/getVo2MaxSamples().md)
       * [getSleepSamples](/docs/getsleepsamples().md)
       * [getStepCount](/docs/getStepCount().md)
       * [getWeightSamples](/docs/getweightsamples().md)
@@ -159,6 +160,7 @@ The available Healthkit permissions to use with `initHealthKit`
 | LeanBodyMass           | [HKQuantityTypeIdentifierLeanBodyMass](https://developer.apple.com/reference/Healthkit/hkquantitytypeidentifierleanbodymass?language=objc)                         | ✓    | ✓     |
 | MindfulSession         | [HKCategoryTypeIdentifierMindfulSession](https://developer.apple.com/reference/healthkit/hkcategorytypeidentifiermindfulsession?language=objc)                     |      |  ✓    |
 | RespiratoryRate        | [HKQuantityTypeIdentifierRespiratoryRate](https://developer.apple.com/reference/Healthkit/hkquantitytypeidentifierrespiratoryrate?language=objc)                   | ✓    |       |
+| Vo2Max                 | [HKQuantityTypeIdentifierVo2Max](https://developer.apple.com/reference/Healthkit/hkquantitytypeidentifiervo2max?language=objc)                   | ✓    |       |
 | SleepAnalysis          | [HKCategoryTypeIdentifierSleepAnalysis](https://developer.apple.com/reference/Healthkit/hkcategorytypeidentifiersleepanalysis?language=objc)                       | ✓    |       |
 | StepCount              | [HKQuantityTypeIdentifierStepCount](https://developer.apple.com/reference/Healthkit/hkquantitytypeidentifierstepcount?language=objc)                               | ✓    | ✓     |
 | Steps                  | [HKQuantityTypeIdentifierSteps](https://developer.apple.com/reference/Healthkit/hkquantitytypeidentifiersteps?language=objc)                                       | ✓    | ✓     |

--- a/docs/getVo2MaxSamples().md
+++ b/docs/getVo2MaxSamples().md
@@ -1,0 +1,23 @@
+Query for Vo2Max samples. the options object is used to setup a query to retrieve relevant samples.
+Note: This API is only available for iOS 11.
+
+```javascript
+let options = {
+  unit: 'bpm', // optional; default 'ml/(kg * min)'
+  startDate: (new Date(2016,4,27)).toISOString(), // required
+  endDate: (new Date()).toISOString(), // optional; default now
+  ascending: false, // optional; default false
+  limit: 10, // optional; default no limit
+};
+```
+
+The callback function will be called with a `samples` array containing objects with *value*, *startDate*, and *endDate* fields
+
+```javascript
+AppleHealthKit.getVo2MaxSamples(options, (err: Object, results: Array<Object>) => {
+  if (err) {
+    return;
+  }
+  console.log(results)
+});
+```


### PR DESCRIPTION
Vo2Max is only available for iOS 11 and above:
```
if (parseInt(Platform.Version, 10) >= 11) {
   const options = { ... }
   AppleHealthKit.getVo2MaxSamples(options, (err, results) => {
      ...
   }
}
```