### PR TITLE
Authorization status

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Activity.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Activity.m
@@ -35,8 +35,7 @@
                                   callback(@[[NSNull null], results]);
                                   return;
                               } else {
-                                  NSLog(@"error getting active energy burned samples: %@", error);
-                                  callback(@[RCTMakeError(@"error getting active energy burned samples", nil, nil)]);
+                                  callback(@[RCTJSErrorFromNSError(error)]);
                                   return;
                               }
                           }];
@@ -65,8 +64,7 @@
                                   callback(@[[NSNull null], results]);
                                   return;
                               } else {
-                                  NSLog(@"error getting basal energy burned samples: %@", error);
-                                  callback(@[RCTMakeError(@"error getting basal energy burned samples", nil, nil)]);
+                                  callback(@[RCTJSErrorFromNSError(error)]);
                                   return;
                               }
                           }];

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Body.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Body.m
@@ -27,8 +27,7 @@
                                     predicate:nil
                                    completion:^(HKQuantity *mostRecentQuantity, NSDate *startDate, NSDate *endDate, NSError *error) {
         if (!mostRecentQuantity) {
-            NSLog(@"error getting latest weight: %@", error);
-            callback(@[RCTMakeError(@"error getting latest weight", error, nil)]);
+            callback(@[RCTJSErrorFromNSError(error)]);
         }
         else {
             // Determine the weight in the required unit.
@@ -71,8 +70,7 @@
             callback(@[[NSNull null], results]);
             return;
         } else {
-            NSLog(@"error getting weight samples: %@", error);
-            callback(@[RCTMakeError(@"error getting weight samples", nil, nil)]);
+            callback(@[RCTJSErrorFromNSError(error)]);
             return;
         }
     }];
@@ -91,8 +89,7 @@
 
     [self.healthStore saveObject:weightSample withCompletion:^(BOOL success, NSError *error) {
         if (!success) {
-            NSLog(@"error saving the weight sample: %@", error);
-            callback(@[RCTMakeError(@"error saving the weight sample", error, nil)]);
+            callback(@[RCTJSErrorFromNSError(error)]);
             return;
         }
         callback(@[[NSNull null], @(weight)]);
@@ -108,8 +105,7 @@
                                     predicate:nil
                                    completion:^(HKQuantity *mostRecentQuantity, NSDate *startDate, NSDate *endDate, NSError *error) {
         if (!mostRecentQuantity) {
-            NSLog(@"error getting latest BMI: %@", error);
-            callback(@[RCTMakeError(@"error getting latest BMI", error, nil)]);
+            callback(@[RCTJSErrorFromNSError(error)]);
         }
         else {
             // Determine the bmi in the required unit.
@@ -140,8 +136,7 @@
 
     [self.healthStore saveObject:bmiSample withCompletion:^(BOOL success, NSError *error) {
         if (!success) {
-            NSLog(@"error saving BMI sample: %@.", error);
-            callback(@[RCTMakeError(@"error saving BMI sample", error, nil)]);
+            callback(@[RCTJSErrorFromNSError(error)]);
             return;
         }
         callback(@[[NSNull null], @(bmi)]);
@@ -206,8 +201,7 @@
           callback(@[[NSNull null], results]);
           return;
         } else {
-          NSLog(@"error getting height samples: %@", error);
-          callback(@[RCTMakeError(@"error getting height samples", error, nil)]);
+          callback(@[RCTJSErrorFromNSError(error)]);
           return;
         }
     }];
@@ -230,8 +224,7 @@
 
     [self.healthStore saveObject:heightSample withCompletion:^(BOOL success, NSError *error) {
         if (!success) {
-            NSLog(@"error saving height sample: %@", error);
-            callback(@[RCTMakeError(@"error saving height sample", error, nil)]);
+            callback(@[RCTJSErrorFromNSError(error)]);
             return;
         }
         callback(@[[NSNull null], @(height)]);
@@ -247,8 +240,7 @@
                                     predicate:nil
                                    completion:^(HKQuantity *mostRecentQuantity, NSDate *startDate, NSDate *endDate, NSError *error) {
         if (!mostRecentQuantity) {
-            NSLog(@"error getting latest body fat percentage: %@", error);
-            callback(@[RCTMakeError(@"error getting latest body fat percentage", error, nil)]);
+            callback(@[RCTJSErrorFromNSError(error)]);
         }
         else {
             // Determine the weight in the required unit.
@@ -277,8 +269,7 @@
                                     predicate:nil
                                    completion:^(HKQuantity *mostRecentQuantity, NSDate *startDate, NSDate *endDate, NSError *error) {
         if (!mostRecentQuantity) {
-            NSLog(@"error getting latest lean body mass: %@", error);
-            callback(@[RCTMakeError(@"error getting latest lean body mass", error, nil)]);
+            callback(@[RCTJSErrorFromNSError(error)]);
         }
         else {
             HKUnit *weightUnit = [HKUnit poundUnit];

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Characteristic.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Characteristic.m
@@ -34,8 +34,7 @@
     }
 
     if(value == nil){
-        NSLog(@"error getting biological sex: %@", error);
-        callback(@[RCTMakeError(@"error getting biological sex", error, nil)]);
+        callback(@[RCTJSErrorFromNSError(error)]);
         return;
     }
 
@@ -52,8 +51,7 @@
     NSDate *dob = [self.healthStore dateOfBirthWithError:&error];
 
     if(error != nil){
-        NSLog(@"error getting date of birth: %@", error);
-        callback(@[RCTMakeError(@"error getting date of birth", error, nil)]);
+        callback(@[RCTJSErrorFromNSError(error)]);
         return;
     }
     if(dob == nil) {

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
@@ -34,8 +34,7 @@
                                     day:date
                              completion:^(double value, NSDate *startDate, NSDate *endDate, NSError *error) {
         if (!value) {
-            NSLog(@"could not fetch step count for day: %@", error);
-            callback(@[RCTMakeError(@"could not fetch step count for day", error, nil)]);
+            callback(@[RCTJSErrorFromNSError(error)]);
             return;
         }
 
@@ -72,8 +71,7 @@
                                            limit:limit
                                       completion:^(NSArray *arr, NSError *err){
         if (err != nil) {
-            NSLog(@"error with fetchCumulativeSumStatisticsCollection: %@", err);
-            callback(@[RCTMakeError(@"error with fetchCumulativeSumStatisticsCollection", err, nil)]);
+            callback(@[RCTJSErrorFromNSError(err)]);
             return;
         }
         callback(@[[NSNull null], arr]);
@@ -99,8 +97,7 @@
 
     [self.healthStore saveObject:sample withCompletion:^(BOOL success, NSError *error) {
         if (!success) {
-            NSLog(@"An error occured saving the step count sample %@. The error was: %@.", sample, error);
-            callback(@[RCTMakeError(@"An error occured saving the step count sample", error, nil)]);
+            callback(@[RCTJSErrorFromNSError(error)]);
             return;
         }
         callback(@[[NSNull null], @(value)]);
@@ -122,9 +119,7 @@
                      NSError *error) {
 
          if (error) {
-             // Perform Proper Error Handling Here...
-             NSLog(@"*** An error occured while setting up the stepCount observer. %@ ***", error.localizedDescription);
-             callback(@[RCTMakeError(@"An error occured while setting up the stepCount observer", error, nil)]);
+             callback(@[RCTJSErrorFromNSError(error)]);
              return;
          }
 
@@ -149,8 +144,7 @@
 
     [self fetchSumOfSamplesOnDayForType:quantityType unit:unit day:date completion:^(double distance, NSDate *startDate, NSDate *endDate, NSError *error) {
         if (!distance) {
-            NSLog(@"ERROR getting DistanceWalkingRunning: %@", error);
-            callback(@[RCTMakeError(@"ERROR getting DistanceWalkingRunning", error, nil)]);
+            callback(@[RCTJSErrorFromNSError(error)]);
             return;
         }
 
@@ -187,8 +181,7 @@
                                            limit:limit
                                       completion:^(NSArray *arr, NSError *err){
                                           if (err != nil) {
-                                              NSLog(@"error with fetchCumulativeSumStatisticsCollection: %@", err);
-                                              callback(@[RCTMakeError(@"error with fetchCumulativeSumStatisticsCollection", err, nil)]);
+                                              callback(@[RCTJSErrorFromNSError(err)]);
                                               return;
                                           }
                                           callback(@[[NSNull null], arr]);
@@ -204,8 +197,7 @@
 
     [self fetchSumOfSamplesOnDayForType:quantityType unit:unit day:date completion:^(double distance, NSDate *startDate, NSDate *endDate, NSError *error) {
         if (!distance) {
-            NSLog(@"ERROR getting DistanceCycling: %@", error);
-            callback(@[RCTMakeError(@"ERROR getting DistanceCycling", error, nil)]);
+            callback(@[RCTJSErrorFromNSError(error)]);
             return;
         }
 
@@ -241,8 +233,7 @@
                                            limit:limit
                                       completion:^(NSArray *arr, NSError *err){
                                           if (err != nil) {
-                                              NSLog(@"error with fetchCumulativeSumStatisticsCollection: %@", err);
-                                              callback(@[RCTMakeError(@"error with fetchCumulativeSumStatisticsCollection", err, nil)]);
+                                              callback(@[RCTJSErrorFromNSError(err)]);
                                               return;
                                           }
                                           callback(@[[NSNull null], arr]);
@@ -258,8 +249,7 @@
 
     [self fetchSumOfSamplesOnDayForType:quantityType unit:unit day:date completion:^(double count, NSDate *startDate, NSDate *endDate, NSError *error) {
         if (!count) {
-            NSLog(@"ERROR getting FlightsClimbed: %@", error);
-            callback(@[RCTMakeError(@"ERROR getting FlightsClimbed", error, nil), @(count)]);
+            callback(@[RCTJSErrorFromNSError(error)]);
             return;
         }
 
@@ -295,8 +285,7 @@
                                            limit:limit
                                       completion:^(NSArray *arr, NSError *err){
                                           if (err != nil) {
-                                              NSLog(@"error with fetchCumulativeSumStatisticsCollection: %@", err);
-                                              callback(@[RCTMakeError(@"error with fetchCumulativeSumStatisticsCollection", err, nil)]);
+                                              callback(@[RCTJSErrorFromNSError(err)]);
                                               return;
                                           }
                                           callback(@[[NSNull null], arr]);

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Mindfulness.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Mindfulness.m
@@ -29,8 +29,7 @@
 
     [self.healthStore saveObject:sample withCompletion:^(BOOL success, NSError *error) {
         if (!success) {
-            NSLog(@"An error occured saving the mindful session sample %@. The error was: %@.", sample, error);
-            callback(@[RCTMakeError(@"An error occured saving the mindful session sample", error, nil)]);
+            callback(@[RCTJSErrorFromNSError(error)]);
             return;
         }
         callback(@[[NSNull null], @(value)]);

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.m
@@ -32,8 +32,7 @@
             callback(@[[NSNull null], results]);
             return;
         } else {
-            NSLog(@"error getting blood glucose samples: %@", error);
-            callback(@[RCTMakeError(@"error getting blood glucose samples", nil, nil)]);
+            callback(@[RCTJSErrorFromNSError(error)]);
             return;
         }
     }];

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Sleep.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Sleep.m
@@ -36,8 +36,7 @@
                                              callback(@[[NSNull null], results]);
                                              return;
                                          } else {
-                                             NSLog(@"error getting sleep samples: %@", error);
-                                             callback(@[RCTMakeError(@"error getting sleep samples", nil, nil)]);
+                                             callback(@[RCTJSErrorFromNSError(error)]);
                                              return;
                                          }
                                      }];

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Vitals.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Vitals.m
@@ -33,8 +33,7 @@
             callback(@[[NSNull null], results]);
             return;
         } else {
-            NSLog(@"error getting heart rate samples: %@", error);
-            callback(@[RCTMakeError(@"error getting heart rate samples", nil, nil)]);
+            callback(@[RCTJSErrorFromNSError(error)]);
             return;
         }
     }];

--- a/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.h
@@ -13,5 +13,7 @@
 
 - (NSSet *)getReadPermsFromOptions:(NSArray *)options;
 - (NSSet *)getWritePermsFromOptions:(NSArray *)options;
+- (HKObjectType *)getWritePermFromString:(NSString *)string;
+- (NSString *)getAuthorizationStatusString:(HKAuthorizationStatus)status;
 
 @end

--- a/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
@@ -150,4 +150,18 @@
     return writePermSet;
 }
 
+- (HKObjectType *)getWritePermFromString:(NSString *)writePerm {
+    return [[self writePermsDict] objectForKey:writePerm];
+}
+- (NSString *)getAuthorizationStatusString:(HKAuthorizationStatus)status {
+    switch (status) {
+        case HKAuthorizationStatusNotDetermined:
+            return @"NotDetermined";
+        case HKAuthorizationStatusSharingDenied:
+            return @"SharingDenied";
+        case HKAuthorizationStatusSharingAuthorized:
+            return @"SharingAuthorized";
+    }
+}
+
 @end

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -268,6 +268,26 @@ RCT_EXPORT_METHOD(saveMindfulSession:(NSDictionary *)input callback:(RCTResponse
     }
 }
 
+RCT_EXPORT_METHOD(authorizationStatusForType:(NSString *)type
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject
+{
+    self.healthStore = [[HKHealthStore alloc] init];
+
+    if ([HKHealthStore isHealthDataAvailable]) {
+        HKObjectType *objectType = [self getWritePermFromString:type];
+        if (objectType == nil) {
+            reject(@"unknown write permission", nil, nil);
+            return;
+        }
+
+        NSString *status = [self getAuthorizationStatusString:[self.healthStore authorizationStatusForType:objectType]];
+        resolve(status);
+    } else {
+        reject(@"HealthKit data is not available", nil, nil);
+    }
+})
+
 - (void)getModuleInfo:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
 {
     NSDictionary *info = @{

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -253,9 +253,7 @@ RCT_EXPORT_METHOD(saveMindfulSession:(NSDictionary *)input callback:(RCTResponse
 
         [self.healthStore requestAuthorizationToShareTypes:writeDataTypes readTypes:readDataTypes completion:^(BOOL success, NSError *error) {
             if (!success) {
-                NSString *errMsg = [NSString stringWithFormat:@"Error with HealthKit authorization: %@", error];
-                NSLog(errMsg);
-                callback(@[RCTMakeError(errMsg, nil, nil)]);
+                callback(@[RCTJSErrorFromNSError(error)]);
                 return;
             } else {
                 dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -270,7 +270,9 @@ RCT_EXPORT_METHOD(authorizationStatusForType:(NSString *)type
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject
 {
-    self.healthStore = [[HKHealthStore alloc] init];
+    if (self.healthStore == nil) {
+        self.healthStore = [[HKHealthStore alloc] init];
+    }
 
     if ([HKHealthStore isHealthDataAvailable]) {
         HKObjectType *objectType = [self getWritePermFromString:type];

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ AppleHealthKit.initHealthKit(options: Object, (err: string, results: Object) => 
     * Base Methods
       * [isAvailable](/docs/isAvailable().md)
       * [initHealthKit](/docs/initHealthKit().md)
+      * [authorizationStatusForType](/docs/authorizationStatusForType().md)
     * Realtime Methods
       * [initStepCountObserver](/docs/initStepCountObserver().md)
     * Read Methods

--- a/docs/authorizationStatusForType().md
+++ b/docs/authorizationStatusForType().md
@@ -4,7 +4,7 @@ Status will be one of `"NotDetermined"`, `"SharingDenied"`, `"SharingAuthorized"
 
 ```javascript
 AppleHealthKit.authorizationStatusForType(
-  "initHealthKit", (error, status) => {
+  "StepCount", (error, status) => {
     if (status) {
       console.log("status is", status)
     }

--- a/docs/authorizationStatusForType().md
+++ b/docs/authorizationStatusForType().md
@@ -1,0 +1,15 @@
+Check the authorization status for sharing (writing) the specified data type.
+
+Status will be one of `"NotDetermined"`, `"SharingDenied"`, `"SharingAuthorized"`.
+
+```javascript
+AppleHealthKit.authorizationStatusForType(
+  "initHealthKit", (error, status) => {
+    if (status) {
+      console.log("status is", status)
+    }
+  }
+)
+```
+
+There is no way to check authorization status for read permission, [see this](https://developer.apple.com/documentation/healthkit/hkhealthstore/1614154-authorizationstatusfortype?language=objc).

--- a/docs/authorizationStatusForType().md
+++ b/docs/authorizationStatusForType().md
@@ -3,13 +3,14 @@ Check the authorization status for sharing (writing) the specified data type.
 Status will be one of `"NotDetermined"`, `"SharingDenied"`, `"SharingAuthorized"`.
 
 ```javascript
-AppleHealthKit.authorizationStatusForType(
-  "StepCount", (error, status) => {
-    if (status) {
-      console.log("status is", status)
-    }
-  }
-)
+try {
+const status = await AppleHealthKit.authorizationStatusForType("StepCount")
+if (status) {
+  console.log("status is", status)
+}
+} catch (error) {
+  console.warn(error)
+}
 ```
 
 There is no way to check authorization status for read permission, [see this](https://developer.apple.com/documentation/healthkit/hkhealthstore/1614154-authorizationstatusfortype?language=objc).


### PR DESCRIPTION
Adds bridge method `authorizationStatusForType` in order for JS code to detect if the app has a certain permission.

Also changes all NSError situations to preserve the native error information over to the JS side, using `RCTJSErrorFromNSError` instead of making a new error object. Remove `NSLog` because I didn't see any reason to log all of these expected situations, and with the full error information that can be done from JS side, if desired.