### PR TITLE
feat: rn60 podspec

### DIFF
--- a/rn-apple-healthkit.podspec
+++ b/rn-apple-healthkit.podspec
@@ -1,0 +1,19 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+  s.platform     = :ios, "10.0"
+
+  s.source       = { :git => "https://github.com/terrillo/rn-apple-healthkit.git", :tag => "v#{s.version}" }
+  s.source_files  = "RCTAppleHealthKit/**/*.{h,m}"
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
add a podspec file driven by package.json as per RN recommendations: 

    - Contact the library maintainers or send them a PR to add a podspec. The react-native-webview podspec is a good example of a package.json driven podspec. See
    https://github.com/react-native-community/react-native-webview/blob/master/react-native-webview.podspec