### PR TITLE
Support asking for DateOfBirth permission

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
@@ -15,7 +15,9 @@
 
 - (nullable HKObjectType *)getReadPermFromText:(nonnull NSString*)key {
     // Characteristic Identifiers
-    if ([@"Height" isEqualToString: key]) {
+    if ([@"DateOfBirth" isEqualToString: key]) {
+        return [HKObjectType characteristicTypeForIdentifier:HKCharacteristicTypeIdentifierDateOfBirth];
+    }else if ([@"Height" isEqualToString: key]) {
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierHeight];
     }else if ([@"Weight" isEqualToString: key]) {
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierBodyMass];


### PR DESCRIPTION
Initializing HealthKit asking for the `DateOfBirth` read permission didn't seem to work in our application: no such permission was being asked in the permission screen. I traced this back to the fact that there's nothing that translates the `@"DateOfBirth"` string literal into the appropriate object.