### PR TITLE
TypesAndPermissions : Fix Workout

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
@@ -97,6 +97,11 @@
         return [HKObjectType workoutType];
     }
     
+    // workouts: real one!
+    if ([@"Workout" isEqualToString: key]) {
+        return [HKObjectType workoutType];
+    }
+
     return nil;
 }
 


### PR DESCRIPTION
After a lot of debugging, it turns out that samples of workout are readable only with the workout permission. But there was no way to add this permission to the initHealthKit permissions options.